### PR TITLE
Add default value for optional parameter to simplify client code

### DIFF
--- a/TAPKit-iOS/TAPKit.swift
+++ b/TAPKit-iOS/TAPKit.swift
@@ -38,7 +38,7 @@ extension TAPKit {
         self.kitCentral.remove(delegate: delegate)
     }
     
-    @objc public func setTAPInputMode(_ newMode:String, forIdentifiers identifiers : [String]?) -> Void {
+    @objc public func setTAPInputMode(_ newMode:String, forIdentifiers identifiers : [String]? = nil) -> Void {
         self.kitCentral.setTAPInputMode(newMode, forIdentifiers: identifiers)
     }
     


### PR DESCRIPTION
When client code doesn't want to pass a non-nil value, don't force them to pass nil.